### PR TITLE
Ajout des commandes userinfo et serverinfo

### DIFF
--- a/Commandes/serverinfo.js
+++ b/Commandes/serverinfo.js
@@ -1,0 +1,28 @@
+const Discord = require('discord.js');
+
+module.exports = {
+
+    name: "serverinfo",
+    description: "Affiche les informations du serveur",
+    permission: "Aucune",
+    dm: false,
+    category: "Information",
+
+    async run(bot, message) {
+        let guild = message.guild;
+
+        let embed = new Discord.EmbedBuilder()
+        .setColor(bot.color)
+        .setTitle(`Informations sur ${guild.name}`)
+        .setThumbnail(guild.iconURL({ dynamic: true }))
+        .addFields(
+            {name: "ID", value: `${guild.id}`, inline: true},
+            {name: "Crée le", value: `<t:${Math.floor(guild.createdTimestamp / 1000)}:F>`, inline: true},
+            {name: "Membres", value: `${guild.memberCount}`, inline: true}
+        )
+        .setTimestamp()
+        .setFooter({text: "Infos serveur"});
+
+        await message.reply({embeds: [embed]});
+    }
+}

--- a/Commandes/userinfo.js
+++ b/Commandes/userinfo.js
@@ -1,0 +1,37 @@
+const Discord = require('discord.js');
+
+module.exports = {
+
+    name: "userinfo",
+    description: "Affiche les informations d'un utilisateur",
+    permission: "Aucune",
+    dm: false,
+    category: "Information",
+    options: [{
+        type: "user",
+        name: "membre",
+        description: "Membre dont afficher les informations",
+        required: false,
+        autocomplete: false,
+    }],
+
+    async run(bot, message, args) {
+        let user = args?.getUser("membre") || message.user;
+        let member = message.guild.members.cache.get(user.id);
+
+        let embed = new Discord.EmbedBuilder()
+        .setColor(bot.color)
+        .setTitle(`Informations sur ${user.tag}`)
+        .setThumbnail(user.displayAvatarURL({ dynamic: true }))
+        .addFields(
+            {name: "ID", value: `${user.id}`, inline: true},
+            {name: "Compte créé le", value: `<t:${Math.floor(user.createdTimestamp / 1000)}:F>`, inline: true},
+            {name: "A rejoint le serveur", value: member ? `<t:${Math.floor(member.joinedTimestamp / 1000)}:F>` : "Non disponible", inline: true},
+            {name: "Rôles", value: member ? member.roles.cache.map(r => r).join(', ') : "Aucun", inline: false},
+        )
+        .setTimestamp()
+        .setFooter({text: "Infos utilisateur"});
+
+        await message.reply({embeds: [embed]});
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Prymus est un bot Discord créé avec Discord.js pour ajouter des fonctionnalit�
 - Gestion de commandes simples et avancées.
 - Interaction avec les membres du serveur.
 - Personnalisation facile via les fichiers de configuration.
+- Nouvelles commandes `serverinfo` et `userinfo` pour obtenir des informations détaillées.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add a userinfo command that displays information about a user
- add a serverinfo command for server details
- document the new commands in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9d9e1a8832b8923e3c8d1a6d768